### PR TITLE
React-components: Add possibility to use same width for Popper and Popover components

### DIFF
--- a/packages/react-components/src/ComboBox/combo_box.tsx
+++ b/packages/react-components/src/ComboBox/combo_box.tsx
@@ -339,6 +339,7 @@ export const ComboBox = React.forwardRef<HTMLDivElement, ComboBoxProps>((props, 
         anchorEl={rootRef.current}
         onClose={handlePopoverClose}
         placement="bottom-start"
+        allowUseSameWidth
       >
         <div
           role="listbox"

--- a/packages/react-components/src/Popover/popover.tsx
+++ b/packages/react-components/src/Popover/popover.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { Placement } from '@popperjs/core';
-import { usePopper } from 'react-popper';
+import { usePopper, PopperProps, Modifier } from 'react-popper';
 import { Modal, ModalProps } from '../Modal';
 import { Box } from '../Box';
 import { Fade } from '../Fade';
@@ -22,7 +21,7 @@ type BaseProps = {
   /**
    * Popover placement.
    */
-  placement?: Placement;
+  placement?: PopperProps<unknown>['placement'];
   /**
    * Callback fired when the component requests to be closed.
    */
@@ -31,6 +30,10 @@ type BaseProps = {
    * Props applied to the `Modal` element.
    */
   modalProps?: Partial<ModalProps>;
+  /**
+   * Make your popover the same width as the reference.
+   */
+  allowUseSameWidth?: boolean;
 };
 
 export type PopoverProps = BaseProps & Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>;
@@ -54,14 +57,36 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>((props, re
     onClose,
     className,
     modalProps,
+    allowUseSameWidth,
     ...other
   } = props;
 
   const [popperElement, setPopperElement] = React.useState(null);
+  const sameWidthModifier: Modifier<'sameWidth'> = React.useMemo(
+    () => ({
+      name: 'sameWidth',
+      enabled: allowUseSameWidth,
+      phase: 'beforeWrite',
+      requires: ['computeStyles'],
+      fn: ({ state }) => {
+        // eslint-disable-next-line no-param-reassign
+        state.styles.popper.width = `${state.rects.reference.width}px`;
+      },
+      effect: ({ state }) => {
+        // @ts-ignore
+        // eslint-disable-next-line no-param-reassign
+        state.elements.popper.style.width = `${state.elements.reference.offsetWidth}px`;
+      },
+    }),
+    [],
+  );
   const { styles, attributes } = usePopper(
     anchorEl,
     popperElement,
-    { placement },
+    {
+      placement,
+      modifiers: [sameWidthModifier],
+    },
   );
 
   return (
@@ -101,4 +126,5 @@ Popover.displayName = 'Popover';
 
 Popover.defaultProps = {
   placement: 'bottom-end',
+  allowUseSameWidth: false,
 };

--- a/packages/react-components/src/SelectPicker/select_picker.story.tsx
+++ b/packages/react-components/src/SelectPicker/select_picker.story.tsx
@@ -104,19 +104,30 @@ const top100Films = [
   { title: 'Monty Python and the Holy Grail', year: 1975 },
 ];
 
-const Template = () => (
+const Template = (args: any) => (
   <SelectPicker
-    options={top100Films}
-    getOptionLabel={(option: any) => option.title}
-    placeholder="Select a movie"
-    allowCreateNew
+    {...args}
   />
 );
 
 export const Playground = Template.bind({});
-Playground.args = {};
+Playground.args = {
+  options: top100Films,
+  getOptionLabel: (option: any) => option.title,
+  placeholder: 'Select a movie',
+  allowCreateNew: true,
+};
 
 export default {
   title: 'Components/SelectPicker',
   component: SelectPicker,
+  argTypes: {
+    options: { control: false },
+    getOptionLabel: { control: false },
+    loadingText: { control: false },
+    noOptionsText: { control: false },
+    defaultValue: { control: false },
+    value: { control: false },
+    filterOptions: { control: false },
+  },
 };

--- a/packages/react-components/src/SelectPicker/select_picker.tsx
+++ b/packages/react-components/src/SelectPicker/select_picker.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-} from 'react';
+import React from 'react';
 import { Popover } from '../Popover';
 import { TextField } from '../TextField';
 import { Typography } from '../Typography';
@@ -297,12 +292,12 @@ export const SelectPicker: <T>(props: SelectPickerProps<T>) => JSX.Element = (pr
     onOpen,
   } = props;
 
-  const [open, setOpen] = useState<boolean>(false);
-  const [searchValue, setSearchValue] = useState<string>('');
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [searchValue, setSearchValue] = React.useState<string>('');
 
-  const rootRef = useRef(null);
+  const rootRef = React.useRef(null);
   const listboxRef = React.useRef(null);
-  const highlightedIndexRef = useRef(-1);
+  const highlightedIndexRef = React.useRef(-1);
 
   const [value, setValue] = useControllableState({
     value: valueProp,
@@ -479,7 +474,7 @@ export const SelectPicker: <T>(props: SelectPickerProps<T>) => JSX.Element = (pr
     setHighlightedIndex(nextIndex, reason);
   };
 
-  const syncHighlightedIndex = useCallback(() => {
+  const syncHighlightedIndex = React.useCallback(() => {
     if (!open) {
       return;
     }
@@ -569,7 +564,7 @@ export const SelectPicker: <T>(props: SelectPickerProps<T>) => JSX.Element = (pr
     }
   };
 
-  useEffect(() => {
+  React.useEffect(() => {
     syncHighlightedIndex();
   }, [syncHighlightedIndex]);
 
@@ -686,6 +681,7 @@ export const SelectPicker: <T>(props: SelectPickerProps<T>) => JSX.Element = (pr
         onClose={handleClose}
         placement="bottom-start"
         className={stylesPopper()}
+        allowUseSameWidth
       >
         <Box
           borderColor="gray-3"


### PR DESCRIPTION
Before:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/9417251/157471284-3f86cc26-ae39-4ba1-b4f6-32a008edf6d4.png">
After:
<img width="988" alt="image" src="https://user-images.githubusercontent.com/9417251/157471192-05cbd1eb-a802-4d6a-b5f0-f0d74b355502.png">
