### PR TITLE
React-components: Fix Switch dot size

### DIFF
--- a/packages/react-components/src/Switch/switch.tsx
+++ b/packages/react-components/src/Switch/switch.tsx
@@ -117,6 +117,7 @@ const stylesDot = () => css({
   transform: 'translate(calc(2px), -50%)',
   transition: 'transform 200ms',
   boxShadow: 'var(--pv-shadow-light-low)',
+  boxSizing: 'content-box',
 });
 
 export const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>((props, ref) => {


### PR DESCRIPTION
Since the "box-sizing: border-box" property is used, dot sizes are distorted.

<img width="200" alt="image" src="https://user-images.githubusercontent.com/47363177/163156952-a0d8c315-d736-413e-874c-a9dc7f5d09dd.png">
