### PR TITLE
React Components: Fix long word in toast text bug

### DIFF
--- a/packages/react-components/src/Toast/toast_container.tsx
+++ b/packages/react-components/src/Toast/toast_container.tsx
@@ -18,6 +18,7 @@ const stylesBase = () => css({
   zIndex: 1300,
   width: '100%',
   maxWidth: '460px',
+  wordBreak: 'break-word',
   left: '50%',
   transform: 'translateX(-50%)',
   '& > * + *': {


### PR DESCRIPTION
If a long word passed in a toast message, it looks broken
<img width="477" src="https://user-images.githubusercontent.com/47363167/170723345-71e5b916-da96-4eac-b9de-3a67b2452f40.png"/>

After fix it looks like this:
<img width="477" alt="image" src="https://user-images.githubusercontent.com/47363167/170725113-b8f654eb-1fd6-4f91-a482-b72f5b563e43.png">


