### PR TITLE
react-components: Assign CSS variables to backdrop in addition to HTML

### DIFF
--- a/packages/react-components/src/styles/theme_provider.tsx
+++ b/packages/react-components/src/styles/theme_provider.tsx
@@ -25,7 +25,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = (props) => {
     <>
       <Global
         styles={{
-          html: createThemeCSSVariablesFromObject(theme),
+          'html, ::backdrop': createThemeCSSVariablesFromObject(theme),
         }}
       />
       {children}


### PR DESCRIPTION
Since native `::backdrop` does not receive any CSS variables outside itself, if we would need to use ::backdrop with customized styles and use CSS variables from theme, we need this change.