### PR TITLE
Add theme styles to current element

### DIFF
--- a/packages/react-components/src/styles/theme_provider.tsx
+++ b/packages/react-components/src/styles/theme_provider.tsx
@@ -10,6 +10,7 @@ type ThemeProviderProps = {
   children: React.ReactElement;
   theme?: ThemeOptionsType;
   mode?: 'light' | 'dark';
+  cssVarsRoot?: string
 };
 /**
  *
@@ -20,6 +21,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = (props) => {
     children,
     mode,
     theme: themeProp,
+    cssVarsRoot = 'html, ::backdrop',
   } = props;
 
   const theme = React.useMemo(
@@ -28,20 +30,18 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = (props) => {
   );
 
   return (
-    <>
+    <ThemeProviderEmotion
+      theme={{
+        mode,
+      }}
+    >
       <Global
         styles={{
-          'html, ::backdrop': theme,
+          [cssVarsRoot]: theme,
         }}
       />
-      <ThemeProviderEmotion
-        theme={{
-          mode,
-        }}
-      >
-        {children}
-      </ThemeProviderEmotion>
-    </>
+      {children}
+    </ThemeProviderEmotion>
   );
 };
 


### PR DESCRIPTION
Problem: Sometimes it is necessary to put the ThemeProvider in another ThemeProvider, but since the styles are added to the Global, this leads to the abort of the previous styles.

```tsx
<ThemeProvider mode={customMode}>
  <ThemeProvider mode="light">
    {...}
  </ThemeProvider>
</ThemeProvider>
```


The solution is to add the ability for the developer to specify which element will be added styles.

```tsx
<ThemeProvider mode={customMode}>
  <ThemeProvider mode="light" cssVarsRoot="#current-id">
    <div id="current-id">
      {...}
    </div>
  </ThemeProvider>
</ThemeProvider>
```