### PR TITLE
Fix: Activated switch/radio/checkbox states effects

### DIFF
--- a/packages/react-components/src/Checkbox/checkbox.tsx
+++ b/packages/react-components/src/Checkbox/checkbox.tsx
@@ -93,6 +93,9 @@ const CheckboxInput = styled('input')(
     let backgroundColorChecked = 'var(--pv-color-primary)';
     let colorDisabledChecked = 'var(--pv-color-gray-7)';
     let iconColorDisabledChecked = 'var(--pv-color-white)';
+    let opacityHover = 0.18;
+    let opacityFocus = 0.23;
+    let opacityActive = 0.30;
 
     if (isDark) {
       color = 'var(--pv-color-gray-7)';
@@ -100,6 +103,9 @@ const CheckboxInput = styled('input')(
       backgroundColorChecked = 'var(--pv-color-primary-tint-1)';
       colorDisabledChecked = 'var(--pv-color-gray-5)';
       iconColorDisabledChecked = 'var(--pv-color-gray-8)';
+      opacityHover = 0.35;
+      opacityFocus = 0.45;
+      opacityActive = 0.55;
     }
 
     return ({
@@ -120,17 +126,17 @@ const CheckboxInput = styled('input')(
         },
         '&:hover': {
           '&:before': {
-            opacity: 0.18,
+            opacity: opacityHover,
           },
         },
         '&:focus-visible': {
           '&:before': {
-            opacity: 0.23,
+            opacity: opacityFocus,
           },
         },
         '&:active': {
           '&:before': {
-            opacity: 0.30,
+            opacity: opacityActive,
           },
         },
       },

--- a/packages/react-components/src/Radio/radio.tsx
+++ b/packages/react-components/src/Radio/radio.tsx
@@ -109,6 +109,9 @@ const RadioInput = styled('input')(
     let ellipseColorChecked = 'var(--pv-color-primary)';
     let colorDisabled = 'var(--pv-color-gray-6)';
     let colorDisabledChecked = 'var(--pv-color-gray-7)';
+    let opacityHover = 0.18;
+    let opacityFocus = 0.23;
+    let opacityActive = 0.30;
 
     if (isDark) {
       color = 'var(--pv-color-gray-7)';
@@ -117,6 +120,9 @@ const RadioInput = styled('input')(
       colorDisabled = 'var(--pv-color-gray-5)';
       colorDisabled = 'var(--pv-color-gray-5)';
       colorDisabledChecked = 'var(--pv-color-gray-5)';
+      opacityHover = 0.35;
+      opacityFocus = 0.45;
+      opacityActive = 0.55;
     }
 
     return ({
@@ -134,17 +140,17 @@ const RadioInput = styled('input')(
         },
         '&:hover': {
           '&:before': {
-            opacity: 0.18,
+            opacity: opacityHover,
           },
         },
         '&:focus-visible': {
           '&:before': {
-            opacity: 0.23,
+            opacity: opacityFocus,
           },
         },
         '&:active': {
           '&:before': {
-            opacity: 0.30,
+            opacity: opacityActive,
           },
         },
       },

--- a/packages/react-components/src/Switch/switch.tsx
+++ b/packages/react-components/src/Switch/switch.tsx
@@ -93,6 +93,9 @@ const SwitchInput = styled('input', {
     let borderColorDisabled = 'var(--pv-color-gray-3)';
     let backgroundColorDisabled = 'var(--pv-color-gray-1)';
     let backgroundColorDisabledChecked = `var(--pv-color-${props.color}-tint-3)`;
+    let opacityHover = 0.18;
+    let opacityFocus = 0.23;
+    let opacityActive = 0.30;
 
     if (isDark) {
       backgroundColorChecked = `var(--pv-color-${props.color}-tint-1)`;
@@ -100,6 +103,9 @@ const SwitchInput = styled('input', {
       borderColorDisabled = 'var(--pv-color-gray-6)';
       backgroundColorDisabled = 'var(--pv-color-gray-7)';
       backgroundColorDisabledChecked = `var(--pv-color-${props.color}-shade-3)`;
+      opacityHover = 0.35;
+      opacityFocus = 0.45;
+      opacityActive = 0.55;
     }
 
     return {
@@ -133,17 +139,17 @@ const SwitchInput = styled('input', {
         },
         '&:hover': {
           '+ [aria-hidden]:before': {
-            opacity: 0.18,
+            opacity: opacityHover,
           },
         },
         '&:focus-visible': {
           '+ [aria-hidden]:before': {
-            opacity: 0.23,
+            opacity: opacityFocus,
           },
         },
         '&:active': {
           '+ [aria-hidden]:before': {
-            opacity: 0.30,
+            opacity: opacityActive,
           },
         },
       },


### PR DESCRIPTION
Problem: Activated switch/radio/checkbox states effects have very low contrast (DM).

Updated [mockup](https://www.figma.com/file/MJze0qkQ2bw0D1oelqqOUK/pv-design-system?type=design&node-id=8694-25145&mode=design&t=Imi0C5csUmq0qBWF-4).