### PR TITLE
Add missed `boxShadow` prop to `Box` `reactPropsRegex`

### DIFF
--- a/packages/react-components/src/Box/__snapshots__/box.test.tsx.snap
+++ b/packages/react-components/src/Box/__snapshots__/box.test.tsx.snap
@@ -109,7 +109,6 @@ exports[`<Box /> box shadow shadow "dark-hight" 1`] = `
 }
 
 <div
-    boxshadow="dark-hight"
     class="emotion-0"
   >
     Message
@@ -124,7 +123,6 @@ exports[`<Box /> box shadow shadow "dark-medium" 1`] = `
 }
 
 <div
-    boxshadow="dark-medium"
     class="emotion-0"
   >
     Message
@@ -139,7 +137,6 @@ exports[`<Box /> box shadow shadow "light-hight" 1`] = `
 }
 
 <div
-    boxshadow="light-hight"
     class="emotion-0"
   >
     Message
@@ -154,7 +151,6 @@ exports[`<Box /> box shadow shadow "light-low" 1`] = `
 }
 
 <div
-    boxshadow="light-low"
     class="emotion-0"
   >
     Message
@@ -169,7 +165,6 @@ exports[`<Box /> box shadow shadow "light-medium" 1`] = `
 }
 
 <div
-    boxshadow="light-medium"
     class="emotion-0"
   >
     Message
@@ -184,7 +179,6 @@ exports[`<Box /> box shadow shadow "light-soft" 1`] = `
 }
 
 <div
-    boxshadow="light-soft"
     class="emotion-0"
   >
     Message

--- a/packages/react-components/src/Box/box.tsx
+++ b/packages/react-components/src/Box/box.tsx
@@ -34,7 +34,7 @@ export type BoxProps<
  *
  */
 
-const reactPropsRegex = /^(as|background|borderColor|borderWidth|borderStyle|borderPosition|borderRadius)$/;
+const reactPropsRegex = /^(as|background|borderColor|borderWidth|borderStyle|borderPosition|borderRadius|boxShadow)$/;
 
 /**
  * Styles.


### PR DESCRIPTION
Missed `boxShadow` prop [here](https://github.com/PeculiarVentures/peculiar-ui/blob/main/packages/react-components/src/Box/box.tsx#L37) leading to rendering element with `boxshadow` attribute:

<img width="216" alt="Screenshot 2024-08-02 at 13 27 36" src="https://github.com/user-attachments/assets/8ed64ecb-5d56-471f-aeae-0e271fd56640">
